### PR TITLE
Add backend CI workflow to run backend tests

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,27 @@
+name: Backend CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r backend/requirements.txt
+
+      - name: Run backend tests
+        run: |
+          export PYTHONPATH=backend
+          python -m pytest backend/tests


### PR DESCRIPTION
This adds a new backend-ci workflow that installs backend dependencies and runs pytest with PYTHONPATH=backend. It isolates the backend test job to avoid YAML syntax errors from the previous main.yml workflow.